### PR TITLE
修改命名规则，防止复杂json相同字段导致命名重复

### DIFF
--- a/JSONConverter/Classes/Builder/JSONBuilder.swift
+++ b/JSONConverter/Classes/Builder/JSONBuilder.swift
@@ -92,6 +92,9 @@ class JSONBuilder {
                 propertyModel = file.propertyWithPreviousNodeName(previousNodeName, keyName: keyName, type: .ArrayDictionary)
                 let content = addDictionaryWithPreviousNodeName(previousNodeName, keyName: keyName, dic: dic)
                 file.contents.insert(content, at: 0)
+            case let arr as [Any]:
+                propertyModel = addArraryWithPreviousNodeName(previousNodeName, keyName: keyName, valueArrary: arr)
+                break
             default:
                 assertionFailure("build JSON object type error")
                 break

--- a/JSONConverter/Classes/Builder/JSONBuilder.swift
+++ b/JSONConverter/Classes/Builder/JSONBuilder.swift
@@ -25,9 +25,9 @@ class JSONBuilder {
         
         switch obj {
         case let dic as [String: Any]:
-            content = addDictionaryWithKeyName(propertyKey, dic: dic)
+            content = addDictionaryWithPreviousNodeName("", keyName: propertyKey, dic: dic)
         case let arr as [Any]:
-            _ = addArraryWithKeyName(propertyKey, valueArrary: arr)
+            _ = addArraryWithPreviousNodeName("", keyName: propertyKey, valueArrary: arr)
         default:
             assertionFailure("parse object type error")
         }
@@ -40,8 +40,8 @@ class JSONBuilder {
     }
     
     
-    private func addDictionaryWithKeyName(_ keyName: String, dic: [String: Any]) -> Content {
-        let content = file.contentWithKeyName(keyName)
+    private func addDictionaryWithPreviousNodeName(_ rootClassName: String, keyName: String, dic: [String: Any]) -> Content {
+        let content = file.contentWithPreviousNodeName(rootClassName, keyName: keyName)
         
         dic.forEach { (item) in
             let keyName = item.key
@@ -49,17 +49,17 @@ class JSONBuilder {
             
             switch item.value {
             case _ as String:
-                property = file.propertyWithKeyName(keyName, type: .String)
+                property = file.propertyWithPreviousNodeName(content.className, keyName: keyName, type: .String)
             case let num as NSNumber:
-                property = file.propertyWithKeyName(keyName, type: num.valueType())
+                property = file.propertyWithPreviousNodeName(content.className, keyName: keyName, type: num.valueType())
             case let dic as [String: Any]:
-                property = file.propertyWithKeyName(keyName, type: .Dictionary)
-                let content = addDictionaryWithKeyName(keyName, dic: dic)
+                property = file.propertyWithPreviousNodeName(content.className, keyName: keyName, type: .Dictionary)
+                let content = addDictionaryWithPreviousNodeName(content.className, keyName: keyName, dic: dic)
                 file.contents.insert(content, at: 0)
             case let arr as [Any]:
-                property = addArraryWithKeyName(keyName, valueArrary: arr)
+                property = addArraryWithPreviousNodeName(content.className, keyName: keyName, valueArrary: arr)
             case  _ as NSNull:
-                property = file.propertyWithKeyName(keyName, type: .nil)
+                property = file.propertyWithPreviousNodeName(content.className, keyName: keyName, type: .nil)
             default:
                 assertionFailure("build JSON object type error")
             }
@@ -72,7 +72,7 @@ class JSONBuilder {
         return content
     }
     
-    private func addArraryWithKeyName(_ keyName: String, valueArrary: [Any]) -> Property? {
+    private func addArraryWithPreviousNodeName(_ previousNodeName: String, keyName: String, valueArrary: [Any]) -> Property? {
         var item = valueArrary.first
         if valueArrary.first is Dictionary<String, Any> {
             var temp = [String: Any]()
@@ -84,13 +84,13 @@ class JSONBuilder {
             var propertyModel: Property?
             switch item {
             case _ as String:
-                propertyModel = file.propertyWithKeyName(keyName, type: .ArrayString)
+                propertyModel = file.propertyWithPreviousNodeName(previousNodeName, keyName: keyName, type: .ArrayString)
             case let num as NSNumber:
                 let type = PropertyType(rawValue: num.valueType().rawValue + 6)!
-                propertyModel = file.propertyWithKeyName(keyName, type: type)
+                propertyModel = file.propertyWithPreviousNodeName(previousNodeName, keyName: keyName, type: type)
             case let dic as [String: Any]:
-                propertyModel = file.propertyWithKeyName(keyName, type: .ArrayDictionary)
-                let content = addDictionaryWithKeyName(keyName, dic: dic)
+                propertyModel = file.propertyWithPreviousNodeName(previousNodeName, keyName: keyName, type: .ArrayDictionary)
+                let content = addDictionaryWithPreviousNodeName(previousNodeName, keyName: keyName, dic: dic)
                 file.contents.insert(content, at: 0)
             default:
                 assertionFailure("build JSON object type error")

--- a/JSONConverter/Classes/Model/Content.swift
+++ b/JSONConverter/Classes/Model/Content.swift
@@ -11,6 +11,10 @@ import Foundation
 class Content {
     var properties = [Property]()
     
+    var previousNodeName: String
+    
+    var className: String
+    
     var propertyKey: String
     
     var langStruct: LangStruct
@@ -21,17 +25,22 @@ class Content {
     
     var autoCaseUnderline: Bool
     
-    init(propertyKey: String, langStruct: LangStruct, parentClsName: String?, prefixStr: String?, autoCaseUnderline: Bool) {
+    init(previousNodeName: String, propertyKey: String, langStruct: LangStruct, parentClsName: String?, prefixStr: String?, autoCaseUnderline: Bool) {
+        self.previousNodeName = previousNodeName
         self.propertyKey = propertyKey
         self.langStruct = langStruct
         self.parentClsName = parentClsName
         self.prefixStr = prefixStr
         self.autoCaseUnderline = autoCaseUnderline
+        
+        let tempPropertyKey = autoCaseUnderline ? propertyKey.underlineToHump() : propertyKey
+        className = tempPropertyKey.className(withPrefix: prefixStr)
+        if !previousNodeName.isEmpty {
+            className = "\(previousNodeName)\(tempPropertyKey.uppercaseFirstChar())"
+        }
     }
     
     func toString() -> String {
-        let tempPropertyKey = autoCaseUnderline ? propertyKey.underlineToHump() : propertyKey
-        let className = tempPropertyKey.className(withPrefix: prefixStr)
         var contentStr = ""
         
         let result = constructPropertyAndSetup()

--- a/JSONConverter/Classes/Model/File.swift
+++ b/JSONConverter/Classes/Model/File.swift
@@ -51,13 +51,13 @@ class File {
         }
     }
     
-    func contentWithKeyName(_ keyName: String) -> Content {
-        let content = Content(propertyKey: keyName, langStruct: langStruct, parentClsName: parentName, prefixStr: prefix, autoCaseUnderline: autoCaseUnderline)
+    func contentWithPreviousNodeName(_ previousNodeName: String, keyName: String) -> Content {
+        let content = Content(previousNodeName: previousNodeName, propertyKey: keyName, langStruct: langStruct, parentClsName: parentName, prefixStr: prefix, autoCaseUnderline: autoCaseUnderline)
         return content
     }
     
-    func propertyWithKeyName(_ keyName: String, type: PropertyType) -> Property {
-        let property = Property(propertyKey: keyName, type: type, langStruct: langStruct, prefixStr: prefix, autoCaseUnderline: autoCaseUnderline)
+    func propertyWithPreviousNodeName(_ previousNodeName: String, keyName: String, type: PropertyType) -> Property {
+        let property = Property(previousNodeName: previousNodeName, propertyKey: keyName, type: type, langStruct: langStruct, prefixStr: prefix, autoCaseUnderline: autoCaseUnderline)
         return property
     }
     

--- a/JSONConverter/Classes/Model/Property.swift
+++ b/JSONConverter/Classes/Model/Property.swift
@@ -35,6 +35,10 @@ enum PropertyType: Int {
 
 class Property {
         
+    var previousNodeName: String
+
+    var className: String
+
     var keyName: String
     
     var type: PropertyType
@@ -47,13 +51,21 @@ class Property {
     
     var typeName: String
     
-    init(propertyKey: String, type: PropertyType, langStruct: LangStruct, prefixStr: String?, autoCaseUnderline: Bool, typeName: String? = nil) {
+    init(previousNodeName: String,  propertyKey: String, type: PropertyType, langStruct: LangStruct, prefixStr: String?, autoCaseUnderline: Bool, typeName: String? = nil) {
+        self.previousNodeName = previousNodeName
         self.keyName = propertyKey
         self.type = type
         self.langStruct = langStruct
         self.prefixStr = prefixStr
         self.autoCaseUnderline = autoCaseUnderline
         self.typeName = typeName ?? type.typeName(langStruct)
+        
+        
+        let tempPropertyKey = autoCaseUnderline ? propertyKey.underlineToHump() : propertyKey
+        className = tempPropertyKey.className(withPrefix: prefixStr)
+        if !previousNodeName.isEmpty {
+            className = "\(previousNodeName)\(tempPropertyKey.uppercaseFirstChar())"
+        }
     }
     
     func toString() -> (String, String){
@@ -145,14 +157,14 @@ class Property {
         case .Dictionary:
             switch langStruct.langType{
             case .ObjC:
-                propertyStr = "@property (nonatomic, strong) \(tempPropertyKey.className(withPrefix: prefixStr)) *\(tempPropertyKey);\n"
+                propertyStr = "@property (nonatomic, strong) \(className) *\(tempPropertyKey);\n"
             case .Swift, .HandyJSON, .Codable:
-                propertyStr = "\tvar \(tempPropertyKey): \(tempPropertyKey.className(withPrefix: prefixStr))?\n"
+                propertyStr = "\tvar \(tempPropertyKey): \(className)?\n"
             case .SwiftyJSON:
-                propertyStr = "\tvar \(tempPropertyKey): \(tempPropertyKey.className(withPrefix: prefixStr))?\n"
-                initStr = "\t\t\(tempPropertyKey) = \(tempPropertyKey.className(withPrefix: prefixStr))(json: json[\"\(keyName)\"])\n"
+                propertyStr = "\tvar \(tempPropertyKey): \(className)?\n"
+                initStr = "\t\t\(tempPropertyKey) = \(className)(json: json[\"\(keyName)\"])\n"
             case .ObjectMapper:
-                propertyStr = "\tvar \(tempPropertyKey): \(tempPropertyKey.className(withPrefix: prefixStr))?\n"
+                propertyStr = "\tvar \(tempPropertyKey): \(className)?\n"
                 initStr = "\t\t\(tempPropertyKey)\(currentMapperSpace)<- map[\"\(keyName)\"]\n"
             case .Flutter:
                 propertyStr = "\n\t@JsonKey(name: '\(keyName)')\n\tMap<String,dynamic>? \(tempPropertyKey);\n"
@@ -241,17 +253,17 @@ class Property {
         case .ArrayDictionary:
             switch langStruct.langType{
             case .ObjC:
-                propertyStr = "@property (nonatomic, strong) NSArray<\(tempPropertyKey.className(withPrefix: prefixStr)) *> *\(tempPropertyKey);\n"
+                propertyStr = "@property (nonatomic, strong) NSArray<\(className) *> *\(tempPropertyKey);\n"
             case .Swift, .HandyJSON, .Codable:
-                propertyStr = "\tvar \(tempPropertyKey) = [\(tempPropertyKey.className(withPrefix: prefixStr))]()\n"
+                propertyStr = "\tvar \(tempPropertyKey) = [\(className)]()\n"
             case .SwiftyJSON:
-                propertyStr = "\tvar \(tempPropertyKey) = [\(tempPropertyKey.className(withPrefix: prefixStr))]()\n"
-                initStr = "\t\t\(tempPropertyKey) = json[\"\(keyName)\"].arrayValue.compactMap({ \(tempPropertyKey.className(withPrefix: prefixStr))(json: $0)})\n"
+                propertyStr = "\tvar \(tempPropertyKey) = [\(className)]()\n"
+                initStr = "\t\t\(tempPropertyKey) = json[\"\(keyName)\"].arrayValue.compactMap({ \(className)(json: $0)})\n"
             case .ObjectMapper:
-                propertyStr = "\tvar \(tempPropertyKey) = [\(tempPropertyKey.className(withPrefix: prefixStr))]()\n"
+                propertyStr = "\tvar \(tempPropertyKey) = [\(className)]()\n"
                 initStr = "\t\t\(tempPropertyKey)\(currentMapperSpace)<- map[\"\(keyName)\"]\n"
             case .Flutter:
-                propertyStr = "\n\t@JsonKey(name: '\(keyName)')\n\tList<\(tempPropertyKey.className(withPrefix: prefixStr))>? \(tempPropertyKey);\n"
+                propertyStr = "\n\t@JsonKey(name: '\(keyName)')\n\tList<\(className)>? \(tempPropertyKey);\n"
                 initStr = "this.\(tempPropertyKey),"
             }
         case .nil:

--- a/JSONConverter/Classes/Model/Property.swift
+++ b/JSONConverter/Classes/Model/Property.swift
@@ -161,7 +161,7 @@ class Property {
             case .Swift, .HandyJSON, .Codable:
                 propertyStr = "\tvar \(tempPropertyKey): \(className)?\n"
             case .SwiftyJSON:
-                propertyStr = "\tvar \(tempPropertyKey): \(className)?\n"
+                propertyStr = "\tvar \(tempPropertyKey): \(className)\n"
                 initStr = "\t\t\(tempPropertyKey) = \(className)(json: json[\"\(keyName)\"])\n"
             case .ObjectMapper:
                 propertyStr = "\tvar \(tempPropertyKey): \(className)?\n"


### PR DESCRIPTION
复杂json嵌套下，很多字段名称一样，导致现有命名重复，简单修改了一下命名规则以供参考